### PR TITLE
Fix: use better font on Windows

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,7 @@
 }
 
 body {
+  font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   background-color: #f2f3f5;
   color: #303133;
   margin: 10px;


### PR DESCRIPTION
Currently, the application uses the default Times New Roman font on Windows devices. This looks ugly and hard to read from a UX standpoint. This PR addresses the issue by specifying a sans-serif font in the main CSS file.