### PR TITLE
build: include HEAD branch in production version logic

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -33,7 +33,7 @@ const baseversion = String(
 ).split("-")[0];
 let appversion;
 
-if (branchName === "main") {
+if (branchName === "main" || branchName === "HEAD") {
   appversion = baseversion;
 } else {
   appversion = baseversion + `-${branchName}+${shortCommitId}`;


### PR DESCRIPTION
Add HEAD branch to the condition that determines production version format. This ensures that builds from detached HEAD states (such as CI/CD tag builds) receive the clean version number without branch and commit suffix.