### PR TITLE
build: bump version to 1.5.0 across AppX manifests

### DIFF
--- a/appxmanifests/AppXManifest_arm64.xml
+++ b/appxmanifests/AppXManifest_arm64.xml
@@ -2,7 +2,7 @@
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
-  <Identity Name="heStudioCommunity.APKSignerGUI" ProcessorArchitecture="arm64" Publisher="CN=73AC1CCD-0F7C-48FE-A64D-F404735487C1" Version="1.4.1.0" />
+  <Identity Name="heStudioCommunity.APKSignerGUI" ProcessorArchitecture="arm64" Publisher="CN=73AC1CCD-0F7C-48FE-A64D-F404735487C1" Version="1.5.0.0" />
   <Properties>
     <DisplayName>APKSignerGUI</DisplayName>
     <PublisherDisplayName>heStudio Community</PublisherDisplayName>

--- a/appxmanifests/AppXManifest_x86_64.xml
+++ b/appxmanifests/AppXManifest_x86_64.xml
@@ -2,7 +2,7 @@
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
-  <Identity Name="heStudioCommunity.APKSignerGUI" ProcessorArchitecture="x64" Publisher="CN=73AC1CCD-0F7C-48FE-A64D-F404735487C1" Version="1.4.1.0" />
+  <Identity Name="heStudioCommunity.APKSignerGUI" ProcessorArchitecture="x64" Publisher="CN=73AC1CCD-0F7C-48FE-A64D-F404735487C1" Version="1.5.0.0" />
   <Properties>
     <DisplayName>APKSignerGUI</DisplayName>
     <PublisherDisplayName>heStudio Community</PublisherDisplayName>


### PR DESCRIPTION
Update version number from 1.4.1.0 to 1.5.0.0 in both ARM64 and x64 AppX manifest files to reflect the new minor release version.